### PR TITLE
Add MyTeamPitch page for team-specific pitcher stats

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -61,6 +61,20 @@
                                 {% endif %}
                             </ul>
                         </li>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle" href="#" id="myTeamPitchDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                MyTeamPitch
+                            </a>
+                            <ul class="dropdown-menu" aria-labelledby="myTeamPitchDropdown">
+                                {% if bu_teams %}
+                                    {% for team_name in bu_teams %}
+                                    <li><a class="dropdown-item" href="{{ url_for('main.my_team_pitch_stats', team_name=team_name) }}">{{ team_name }}</a></li>
+                                    {% endfor %}
+                                {% else %}
+                                    <li><a class="dropdown-item" href="#">No teams available</a></li>
+                                {% endif %}
+                            </ul>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/app/templates/my_team_pitch_stats.html
+++ b/app/templates/my_team_pitch_stats.html
@@ -1,0 +1,66 @@
+{% extends 'base.html' %}
+
+{% block title %}My Team - {{ team_name }} Pitcher Stats{% endblock %}
+
+{% block content %}
+<div class="container mt-2">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="mb-0">My Team - {{ team_name }} Pitching</h1>
+        {% if date %}
+        <p class="lead m-0">Stats as of {{ date.strftime('%B %d, %Y') }}</p>
+        {% endif %}
+    </div>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover full-width-table">
+            <thead class="thead-dark">
+                <tr>
+                    <th class="pitcher-stats-cell team-name">Player</th>
+                    <th class="pitcher-stats-cell">APP</th>
+                    <th class="pitcher-stats-cell">GS</th>
+                    <th class="pitcher-stats-cell">QS</th>
+                    <th class="pitcher-stats-cell">INN</th>
+                    <th class="pitcher-stats-cell">ER</th>
+                    <th class="pitcher-stats-cell">ERA</th>
+                    <th class="pitcher-stats-cell">W</th>
+                    <th class="pitcher-stats-cell">L</th>
+                    <th class="pitcher-stats-cell">S</th>
+                    <th class="pitcher-stats-cell">HA</th>
+                    <th class="pitcher-stats-cell">K</th>
+                    <th class="pitcher-stats-cell">BB</th> <!-- Will display BBI -->
+                    <th class="pitcher-stats-cell">BB9</th>
+                    <th class="pitcher-stats-cell">K9</th>
+                    <th class="pitcher-stats-cell">WHIP</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% if players %}
+                    {% for player in players %}
+                    <tr>
+                        <td class="pitcher-stats-cell team-name">{{ player.clean_name }}</td>
+                        <td class="pitcher-stats-cell">{{ "%d"|format(player.APP|int) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%d"|format(player.GS|int) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%d"|format(player.QS|int) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%.1f"|format(player.INN|float) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%d"|format(player.ER|int) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%.2f"|format(player.ERA|float) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%d"|format(player.W|int)}}</td>
+                        <td class="pitcher-stats-cell">{{ "%d"|format(player.L|int) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%d"|format(player.S|int) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%d"|format(player.HA|int)}}</td>
+                        <td class="pitcher-stats-cell">{{ "%d"|format(player.K|int) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%d"|format(player.BBI|int) }}</td> <!-- BBI is base on balls issued (Walks) -->
+                        <td class="pitcher-stats-cell">{{ "%.2f"|format(player.BB9|float) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%.2f"|format(player.K9|float) }}</td>
+                        <td class="pitcher-stats-cell">{{ "%.3f"|format(player.WHIP|float) }}</td>
+                    </tr>
+                    {% endfor %}
+                {% else %}
+                    <tr>
+                        <td colspan="16" class="text-center">No player pitching data available for this team.</td>
+                    </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This feature introduces a 'MyTeamPitch' section, mirroring the 'MyTeamHit' functionality for pitcher statistics.

- Updated `base.html` to include a 'MyTeamPitch' dropdown in the navigation, populated with BU Teams from the existing context processor. Each link directs to a team-specific pitcher stats page.
- Created a new route `/my-team-pitch/<team_name>` in `main.py`. This route fetches year-to-date pitcher statistics for the selected team from the `PitcherStats` model, calculates derived stats (BB9, K9, WHIP), and handles player name cleaning.
- Added a new template `my_team_pitch_stats.html` to display these pitcher statistics. The table format is based on 'Pitch Leaders' but omits the 'BU Team' column and includes a team-specific heading.