### PR TITLE
feat: Add Hitter Analysis page with RC graph

### DIFF
--- a/app/templates/HitterAnalysis.html
+++ b/app/templates/HitterAnalysis.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block title %}Hitter Analysis{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h1 class="mb-4">Hitter Performance Analysis</h1>
+
+    <form method="GET" action="{{ url_for('main.hitter_analysis') }}" class="mb-4">
+        <div class="form-row align-items-end">
+            <div class="col-md-4">
+                <label for="player_name">Select Player:</label>
+                <select name="player_name" id="player_name" class="form-control">
+                    <option value="">-- Select a Player --</option>
+                    {% for player in players %}
+                        <option value="{{ player }}" {% if player == selected_player_name %}selected{% endif %}>{{ player }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-2">
+                <button type="submit" class="btn btn-primary">Load Stats</button>
+            </div>
+        </div>
+    </form>
+
+    {% if selected_player_name %}
+        <h2 class="mb-3">Stats for {{ selected_player_name }}</h2>
+        {% if plot_url %}
+            <div class="text-center">
+                <img src="data:image/png;base64,{{ plot_url }}" alt="Player Stats Graph" class="img-fluid">
+            </div>
+        {% else %}
+            <p class="alert alert-warning">No data found for {{ selected_player_name }} to display a graph.</p>
+        {% endif %}
+    {% else %}
+        <p class="alert alert-info">Please select a player to view their RC over time.</p>
+    {% endif %}
+
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -47,6 +47,9 @@
                         <li class="nav-item">
                             <a class="nav-link {% if request.path == '/games' %}active{% endif %}" href="{{ url_for('main.games') }}">Games</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.path == url_for('main.hitter_analysis') %}active{% endif %}" href="{{ url_for('main.hitter_analysis') }}">Hitter Analysis</a>
+                        </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" href="#" id="myTeamHitDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 MyTeamHit

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ SQLAlchemy==2.0.40
 typing_extensions==4.13.2
 Werkzeug==3.1.3
 WTForms==3.2.1
+matplotlib
+pandas


### PR DESCRIPTION
This commit introduces a new Hitter Analysis page (`/hitter-analysis`) that allows you to visualize a player's Runs Created (RC) over time.

Key features:
- A dropdown menu dynamically populated with all players from the most recent date in the `hitterStats` table.
- Upon selecting a player, a line graph is displayed showing their RC for each date.
- A second line on the graph represents the 7-day moving average of the player's RC.
- The graph is generated using Matplotlib and Pandas.
- The page is accessible via a new "Hitter Analysis" link in the main navigation bar.

Changes include:
- Added `matplotlib` and `pandas` to `requirements.txt`.
- Created a new route and logic in `app/routes/main.py` for hitter analysis.
- Developed a new template `app/templates/HitterAnalysis.html`.
- Updated `app/templates/base.html` to include the navigation link.