### PR TITLE
I've made some changes to the Hitter Analysis page to refine the play…

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -265,7 +265,9 @@ def teamstatsyest():
 @main.route('/hitter-analysis', methods=['GET'])
 def hitter_analysis():
     most_recent_date = db.session.query(db.func.max(HitterStats.Date)).scalar()
-    players_query = db.session.query(HitterStats.Player).filter(HitterStats.Date == most_recent_date).distinct().order_by(HitterStats.Player).all()
+    games_threshold_query = db.session.query(db.func.max(Team.BUGames)).filter(Team.Date == most_recent_date).scalar()
+    games_threshold = games_threshold_query if games_threshold_query is not None else 0
+    players_query = db.session.query(HitterStats.Player).filter(HitterStats.Date == most_recent_date, HitterStats.AB > games_threshold).distinct().order_by(HitterStats.Player).all()
     players = [player[0] for player in players_query]
 
     selected_player_name = request.args.get('player_name')


### PR DESCRIPTION
…er dropdown.

Previously, the dropdown showed all players from `hitterStats` for the most recent date. Now, I've introduced a filter based on At-Bats (ABs).

Here's how it works:
1. I find the most recent date from `hitterStats`.
2. Then, I get the maximum `BUGames` value from the `teamstat` table (using the `Team` model) for that same date. This value becomes a game threshold.
3. If I can't find a `BUGames` value, the threshold defaults to 0.
4. The player dropdown for Hitter Analysis will now only show players from `hitterStats` whose `AB` for that date is greater than the game threshold I determined.

This should give you a more focused list of players, leaving out those with minimal or zero At-Bats, as requested. No template changes were needed for this.