### PR TITLE
fix: Set Y-axis limit for RC chart to 0-10

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -293,6 +293,8 @@ def hitter_analysis():
             plt.grid(True)
             plt.gcf().autofmt_xdate()
 
+            plt.ylim(bottom=0, top=10.0) # <-- ADD THIS LINE
+
             img = BytesIO()
             plt.savefig(img, format='png', bbox_inches='tight')
             plt.close()


### PR DESCRIPTION
Updates the Hitter Analysis page's Runs Created (RC) chart. The Y-axis is now fixed with a lower bound of 0.0 and an upper bound of 10.0.

This change ensures consistent scaling for the RC metric across all player charts, capping the displayed RC at 10.0. The modification is applied within the `hitter_analysis` route by adding `plt.ylim(bottom=0, top=10.0)` before the chart image is generated.