### PR TITLE
refactor: Update Y-axis bounds for RC chart to 2.0-8.0

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -293,7 +293,7 @@ def hitter_analysis():
             plt.grid(True)
             plt.gcf().autofmt_xdate()
 
-            plt.ylim(bottom=0, top=10.0) # <-- ADD THIS LINE
+            plt.ylim(bottom=2.0, top=8.0)
 
             img = BytesIO()
             plt.savefig(img, format='png', bbox_inches='tight')


### PR DESCRIPTION
Adjusts the Y-axis limits for the Runs Created (RC) chart on the Hitter Analysis page. The visible range for RC is now set to a minimum of 2.0 and a maximum of 8.0.

This change modifies the existing `plt.ylim()` call in the `hitter_analysis` route.