### PR TITLE
feat: Add Pitcher Analysis page with ERA graph

### DIFF
--- a/app/templates/PitcherAnalysis.html
+++ b/app/templates/PitcherAnalysis.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block title %}Pitcher Analysis{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h1 class="mb-4">Pitcher Performance Analysis</h1>
+
+    <form method="GET" action="{{ url_for('main.pitcher_analysis') }}" class="mb-4">
+        <div class="form-row align-items-end">
+            <div class="col-md-4">
+                <label for="player_name">Select Pitcher:</label>
+                <select name="player_name" id="player_name" class="form-control">
+                    <option value="">-- Select a Pitcher --</option>
+                    {% for player in players %}
+                        <option value="{{ player }}" {% if player == selected_player_name %}selected{% endif %}>{{ player }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-2">
+                <button type="submit" class="btn btn-primary">Load Stats</button>
+            </div>
+        </div>
+    </form>
+
+    {% if selected_player_name %}
+        <h2 class="mb-3">ERA for {{ selected_player_name }}</h2>
+        {% if plot_url %}
+            <div class="text-center">
+                <img src="data:image/png;base64,{{ plot_url }}" alt="Pitcher ERA Graph" class="img-fluid">
+            </div>
+        {% else %}
+            <p class="alert alert-warning">No ERA data found for {{ selected_player_name }} to display a graph.</p>
+        {% endif %}
+    {% else %}
+        <p class="alert alert-info">Please select a pitcher to view their ERA over time.</p>
+    {% endif %}
+
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -48,7 +48,10 @@
                             <a class="nav-link {% if request.path == '/games' %}active{% endif %}" href="{{ url_for('main.games') }}">Games</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link {% if request.path == url_for('main.hitter_analysis') %}active{% endif %}" href="{{ url_for('main.hitter_analysis') }}">Hitter Analysis</a>
+                            <a class="nav-link {% if request.endpoint == 'main.hitter_analysis' %}active{% endif %}" href="{{ url_for('main.hitter_analysis') }}">Hitter Analysis</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.endpoint == 'main.pitcher_analysis' %}active{% endif %}" href="{{ url_for('main.pitcher_analysis') }}">Pitcher Analysis</a>
                         </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" href="#" id="myTeamHitDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">


### PR DESCRIPTION
This commit introduces a new Pitcher Analysis page (`/pitcher-analysis`), mirroring the functionality of the Hitter Analysis page but tailored for pitcher statistics.

Key features:
- A dropdown menu populated with pitchers from the `pitcherStats` table for the most recent date, filtered by a qualifying number of Innings Pitched (INN > 0.617 * max BUGames for the date).
- Upon selecting a pitcher, a line graph displays their Earned Run Average (ERA) over time.
- A second line on the graph shows the 7-day moving average for ERA.
- The Y-axis for the ERA graph is bounded from 0 to 5.0.
- The graph is generated using Matplotlib and Pandas.
- The page is accessible via a new "Pitcher Analysis" link in the main navigation bar.

Changes include:
- A new route and logic in `app/routes/main.py` for pitcher_analysis.
- A new template `app/templates/PitcherAnalysis.html`.
- An updated `app/templates/base.html` to include the new navigation link.